### PR TITLE
EASY-1239

### DIFF
--- a/src/main/scala/nl/knaw/dans/easy/bagindex/components/BagStoreAccess.scala
+++ b/src/main/scala/nl/knaw/dans/easy/bagindex/components/BagStoreAccess.scala
@@ -50,12 +50,9 @@ trait BagStoreAccess {
   }
 
   private def findBag(container: Path): Try[Path] = Try {
-    resource.managed(Files.list(container)).acquireAndGet {
-      s =>
-        val containedFiles = s.iterator().asScala.toList
-        assert(containedFiles.size == 1, s"Corrupt BagStore, container with less or more than one file: $container")
-        container.resolve(containedFiles.head)
-    }
+    val containedFiles = resource.managed(Files.list(container)).acquireAndGet(_.iterator().asScala.toList)
+    assert(containedFiles.size == 1, s"Corrupt BagStore, container with less or more than one file: $container")
+    container.resolve(containedFiles.head)
   }
 
   /**
@@ -73,7 +70,7 @@ trait BagStoreAccess {
         Success(currentPath)
       else {
         val res = for {
-          subPath <- resource.managed(Files.list(currentPath)).acquireAndGet(_.findFirst().asScala)
+          subPath <- resource.managed(Files.list(currentPath)).acquireAndGet(_.findFirst.asScala)
           length = subPath.getFileName.toString.length
           (path, restPath2) = restPath.splitAt(length)
           newPath = currentPath.resolve(path)
@@ -106,7 +103,7 @@ trait BagStoreAccess {
         def probe(path: Path, length: Int, levels: Int): Int = {
           length match {
             case l if l > 0 =>
-              val p = resource.managed(Files.list(path)).acquireAndGet(_.findFirst().get)
+              val p = resource.managed(Files.list(path)).acquireAndGet(_.findFirst.get)
               probe(p, length - p.getFileName.toString.length, levels + 1)
             case 0 => levels
             case _ => throw new Exception("corrupt bagstore")


### PR DESCRIPTION
Applied a quick-fix to the problem by wrapping the Files.list calls in a scala-arm resource.managed call. This ensures the stream returned by Files.list is closed after use.

Fixes EASY-1239

#### When applied it will...
* Make sure streams returned by Files.list are closed.
