### PR TITLE
EASY-1413: upgrade to Scala 2.12

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,4 +1,4 @@
-system "ansible-galaxy install --force --role-file=#{File.dirname(File.expand_path(__FILE__))}/src/main/ansible/requirements.yml"
+system "ansible-galaxy install --force --role-file=#{File.dirname(File.expand_path(__FILE__))}/src/main/ansible/requirements.yml" if (ARGV[0] == "up" || ARGV[0] == "provision")
 Vagrant.configure(2) do |config|
    config.vm.define "test" do |test|
       test.vm.box = "geerlingguy/centos6"
@@ -8,6 +8,7 @@ Vagrant.configure(2) do |config|
       test.vm.provision "ansible" do |ansible|
         ansible.playbook = "src/main/ansible/vagrant.yml"
         ansible.config_file = "src/main/ansible/ansible.cfg"
+        ansible.compatibility_mode = "2.0"
 #        ansible.verbose = "vvvv"
       end
       test.vm.provider "virtualbox" do |vb|

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-scala-prototype</artifactId>
-        <version>1.63-SNAPSHOT</version>
+        <version>1.64</version>
     </parent>
 
     <groupId>nl.knaw.dans.easy</groupId>
@@ -56,7 +56,6 @@
         <dependency>
             <groupId>org.scalatra</groupId>
             <artifactId>scalatra-scalatest_2.12</artifactId>
-            <scope>test</scope>
         </dependency>
 
         <!-- Scala utils -->

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-scala-prototype</artifactId>
-        <version>1.62</version>
+        <version>1.63-SNAPSHOT</version>
     </parent>
 
     <groupId>nl.knaw.dans.easy</groupId>
@@ -47,40 +47,38 @@
         <!-- testing -->
         <dependency>
             <groupId>org.scalatest</groupId>
-            <artifactId>scalatest_2.11</artifactId>
+            <artifactId>scalatest_2.12</artifactId>
         </dependency>
         <dependency>
             <groupId>org.scalamock</groupId>
-            <artifactId>scalamock-scalatest-support_2.11</artifactId>
+            <artifactId>scalamock-scalatest-support_2.12</artifactId>
         </dependency>
         <dependency>
             <groupId>org.scalatra</groupId>
-            <artifactId>scalatra-scalatest_2.11</artifactId>
-            <version>2.5.0</version>
+            <artifactId>scalatra-scalatest_2.12</artifactId>
             <scope>test</scope>
         </dependency>
 
         <!-- Scala utils -->
         <dependency>
             <groupId>org.scala-lang.modules</groupId>
-            <artifactId>scala-xml_2.11</artifactId>
+            <artifactId>scala-xml_2.12</artifactId>
         </dependency>
         <dependency>
             <groupId>org.json4s</groupId>
-            <artifactId>json4s-native_2.11</artifactId>
+            <artifactId>json4s-native_2.12</artifactId>
         </dependency>
         <dependency>
             <groupId>com.jsuereth</groupId>
-            <artifactId>scala-arm_2.11</artifactId>
+            <artifactId>scala-arm_2.12</artifactId>
         </dependency>
         <dependency>
             <groupId>org.rogach</groupId>
-            <artifactId>scallop_2.11</artifactId>
+            <artifactId>scallop_2.12</artifactId>
         </dependency>
         <dependency>
             <groupId>nl.knaw.dans.lib</groupId>
-            <artifactId>dans-scala-lib</artifactId>
-            <version>1.2</version>
+            <artifactId>dans-scala-lib_2.12</artifactId>
         </dependency>
 
         <!-- Apache Commons -->
@@ -108,7 +106,7 @@
         </dependency>
         <dependency>
             <groupId>org.scalatra</groupId>
-            <artifactId>scalatra_2.11</artifactId>
+            <artifactId>scalatra_2.12</artifactId>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
@@ -120,7 +118,6 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.1.7</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -142,14 +139,12 @@
         <dependency>
             <groupId>gov.loc</groupId>
             <artifactId>bagit</artifactId>
-            <version>5.0.2</version>
         </dependency>
 
         <!-- databases -->
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-dbcp2</artifactId>
-            <version>2.1.1</version>
         </dependency>
         <dependency>
             <groupId>org.postgresql</groupId>
@@ -158,7 +153,6 @@
         <dependency>
             <groupId>org.xerial</groupId>
             <artifactId>sqlite-jdbc</artifactId>
-            <version>3.16.1</version> <!-- TODO add to parent project-->
         </dependency>
     </dependencies>
 

--- a/src/main/scala/nl.knaw.dans.easy.bagindex/server/BagIndexServletComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagindex/server/BagIndexServletComponent.scala
@@ -40,13 +40,13 @@ trait BagIndexServletComponent {
   trait BagIndexServlet extends ScalatraServlet with DebugEnhancedLogging {
 
     private def toXml(bagInfo: BagInfo): Node = {
-    <bag-info>
-      <bag-id>{bagInfo.bagId.toString}</bag-id>
-      <base-id>{bagInfo.baseId.toString}</base-id>
-      <created>{bagInfo.created.toString(dateTimeFormatter)}</created>
-      <doi>{bagInfo.doi}</doi>
-    </bag-info>
-  }
+      <bag-info>
+        <bag-id>{bagInfo.bagId.toString}</bag-id>
+        <base-id>{bagInfo.baseId.toString}</base-id>
+        <created>{bagInfo.created.toString(dateTimeFormatter)}</created>
+        <doi>{bagInfo.doi}</doi>
+      </bag-info>
+    }
 
     private def toJson(bagInfo: BagInfo): JValue = {
       "bag-info" -> {

--- a/src/main/scala/nl.knaw.dans.easy.bagindex/service/ServiceStarter.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagindex/service/ServiceStarter.scala
@@ -41,7 +41,7 @@ class ServiceStarter extends Daemon with DebugEnhancedLogging {
       .doIfFailure {
         case NonFatal(e) => logger.info(s"Service startup failed: ${ e.getMessage }", e)
       }
-      .getOrRecover(throw _)
+      .unsafeGetOrThrow
   }
 
   override def stop(): Unit = {
@@ -52,7 +52,7 @@ class ServiceStarter extends Daemon with DebugEnhancedLogging {
       .doIfFailure {
         case NonFatal(e) => logger.error(s"Service stop failed: ${ e.getMessage }", e)
       }
-      .getOrRecover(throw _)
+      .unsafeGetOrThrow
   }
 
   override def destroy(): Unit = {
@@ -61,6 +61,6 @@ class ServiceStarter extends Daemon with DebugEnhancedLogging {
       .doIfFailure {
         case e => logger.error(s"Service destroy failed: ${ e.getMessage }", e)
       }
-      .getOrRecover(throw _)
+      .unsafeGetOrThrow
   }
 }


### PR DESCRIPTION
fixes EASY-1413

#### When applied it will
* upgrade the project to use Scala_2.12 as the compiler
* use the `dans-scala-lib` functions
* add `compatibility_mode` and extra if-clause to `Vagrantfile`

@DANS-KNAW/easy for review