### PR TITLE
Index force option

### DIFF
--- a/src/main/assembly/dist/cfg/logback.xml
+++ b/src/main/assembly/dist/cfg/logback.xml
@@ -1,11 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <pattern>[%date{ISO8601}] %-5level %msg %n</pattern>
-        </encoder>
-    </appender>
-
     <appender name="FILE"
               class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${user.home}/easy-bag-index.log</file>
@@ -19,7 +13,6 @@
     </appender>
     <root level="warn">
         <appender-ref ref="FILE"/>
-        <appender-ref ref="STDOUT"/>
     </root>
     <logger name="nl.knaw.dans.easy" level="info"/>
 </configuration>

--- a/src/main/scala/nl.knaw.dans.easy.bagindex/command/Command.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagindex/command/Command.scala
@@ -46,7 +46,7 @@ object Command extends App with CommandLineOptionsComponent with ServiceWiring {
         cmd.bagId.toOption
           .map(index.addFromBagStore(_).map(_ => s"Added bag with bagId ${ cmd.bagId() }"))
           .getOrElse {
-            if (commandLine.interaction.deleteBeforeIndexing())
+            if (cmd.force() || commandLine.interaction.deleteBeforeIndexing())
               indexFull.indexBagStore().map(_ => "bag-store index rebuilt successfully.")
             else
               Success("Indexing aborted.")

--- a/src/main/scala/nl.knaw.dans.easy.bagindex/command/CommandLineOptionsComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagindex/command/CommandLineOptionsComponent.scala
@@ -44,7 +44,7 @@ trait CommandLineOptionsComponent {
          |Usage:
          |
          |$printedName \\
-         |${ _________ }| index [bagId]
+         |${ _________ }| index [--force | -f] [bagId]
          |${ _________ }| run-service
          |
          |Options:
@@ -55,6 +55,10 @@ trait CommandLineOptionsComponent {
 
     val index = new Subcommand("index") {
       descr("Adds one bag or the whole bag-store to the index")
+
+      val force: ScallopOption[Boolean] = opt(name = "force", short = 'f', default = Some(false),
+        descr = "force the indexing without asking for confirmation")
+
       val bagId: ScallopOption[BagId] = trailArg[UUID](name = "bagId",
         descr = "the bag identifier to be added",
         required = false)


### PR DESCRIPTION
Adds a force option to the `easy-bag-index index` command to avoid the user interaction. Also removes console logging from configuration. Related/required by https://github.com/DANS-KNAW/easy-delete-dataset/pull/1

@DANS-KNAW/easy for review