### PR TITLE
Improve custom matcher

### DIFF
--- a/src/test/scala/nl/knaw/dans/easy/bagindex/CustomMatchers.scala
+++ b/src/test/scala/nl/knaw/dans/easy/bagindex/CustomMatchers.scala
@@ -17,19 +17,25 @@ package nl.knaw.dans.easy.bagindex
 
 import org.scalatest.matchers.{ MatchResult, Matcher }
 
-import scala.xml.{ Node, Utility }
+import scala.xml.{ Node, PrettyPrinter, XML }
 
 trait CustomMatchers {
 
   // copied from easy-split-multi-deposit
-  class EqualTrimmedMatcher(right: Seq[Node]) extends Matcher[Seq[Node]] {
-    override def apply(left: Seq[Node]): MatchResult = {
+  class EqualTrimmedMatcher(right: Iterable[Node]) extends Matcher[Iterable[Node]] {
+    private val pp = new PrettyPrinter(160, 2)
+
+    private def prepForTest(n: Node) = XML.loadString(pp.format(n))
+
+    private def pretty(ns: Iterable[Node]) = ns.map(n => XML.loadString(pp.format(n))).mkString("\n")
+
+    override def apply(left: Iterable[Node]): MatchResult = {
       MatchResult(
-        left.zip(right).forall { case (l, r) => Utility.trim(l).toString() == Utility.trim(r).toString() },
-        s"$left did not equal $right",
-        s"$left did equal $right"
+        left.zip(right).forall { case (l, r) => prepForTest(l) == prepForTest(r) },
+        s"${ pretty(left) } was not equal to ${ pretty(right) }",
+        s"${ pretty(left) } was equal to ${ pretty(right) }"
       )
     }
   }
-  def equalTrimmed(right: Seq[Node]) = new EqualTrimmedMatcher(right)
+  def equalTrimmed(right: Iterable[Node]) = new EqualTrimmedMatcher(right)
 }


### PR DESCRIPTION
#### When applied it will
* make sure failing tests that compare XML documents will show a `<click to see difference>` in IntelliJ
    * please note that this is copied from https://github.com/DANS-KNAW/easy-split-multi-deposit/pull/113

This PR basically originated from the [comment](https://github.com/DANS-KNAW/easy-deposit-api/pull/54#discussion_r195697089) by @jo-pol, complaining that IntelliJ doesn't provide the mentioned link in custom matchers.

@DANS-KNAW/easy for review