### PR TITLE
EASY-2002: add version to the baseUrl response

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.bagindex/ConfigurationComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagindex/ConfigurationComponent.scala
@@ -34,7 +34,7 @@ trait ConfigurationComponent {
 
   object Configuration {
     def apply(home: Path): Configuration = new Configuration {
-      override val version: String = managed(Source.fromFile(home.resolve("bin/version").toFile)).acquireAndGet(_.mkString)
+      override val version: String = managed(Source.fromFile(home.resolve("bin/version").toFile)).acquireAndGet(_.mkString).stripLineEnd
 
       private val cfgPath = Seq(
         Paths.get(s"/etc/opt/dans.knaw.nl/easy-bag-index/"),

--- a/src/main/scala/nl.knaw.dans.easy.bagindex/server/BagIndexServletComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagindex/server/BagIndexServletComponent.scala
@@ -43,6 +43,8 @@ trait BagIndexServletComponent {
     with PlainLogFormatter
     with DebugEnhancedLogging {
 
+    val version: String
+
     private def toXml(bagInfo: BagInfo): Node = {
       <bag-info>
         <bag-id>{bagInfo.bagId.toString}</bag-id>
@@ -73,7 +75,7 @@ trait BagIndexServletComponent {
     }
 
     get("/") {
-      Ok("EASY Bag Index running.")
+      Ok(s"EASY Bag Index running v$version.")
         .logResponse
     }
 

--- a/src/main/scala/nl.knaw.dans.easy.bagindex/server/ServerWiring.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagindex/server/ServerWiring.scala
@@ -22,6 +22,8 @@ import nl.knaw.dans.easy.bagindex.components.IndexWiring
 trait ServerWiring extends BagIndexServletComponent with BagIndexServerComponent {
   this: IndexWiring with AccessWiring with ConfigurationComponent =>
 
-  val bagIndexServlet: BagIndexServlet = new BagIndexServlet {}
+  val bagIndexServlet: BagIndexServlet = new BagIndexServlet {
+    override val version: String = configuration.version
+  }
   val server: BagIndexServer = new BagIndexServer(configuration.properties.getInt("bag-index.daemon.http.port"))
 }

--- a/src/test/scala/nl/knaw/dans/easy/bagindex/ServerTestSupportFixture.scala
+++ b/src/test/scala/nl/knaw/dans/easy/bagindex/ServerTestSupportFixture.scala
@@ -18,7 +18,7 @@ package nl.knaw.dans.easy.bagindex
 import java.net.{ HttpURLConnection, URL }
 
 import org.apache.commons.io.IOUtils
-import resource._
+import resource.managed
 
 trait ServerTestSupportFixture {
 
@@ -40,5 +40,5 @@ trait ServerTestSupportFixture {
     }
   }
 
-  def successful(version: String): (Int, String) = (200, s"EASY Bag Index running v$version\n.") //TODO how does this newline end up in the response?
+  def successful(version: String): (Int, String) = (200, s"EASY Bag Index running v$version.")
 }

--- a/src/test/scala/nl/knaw/dans/easy/bagindex/ServerTestSupportFixture.scala
+++ b/src/test/scala/nl/knaw/dans/easy/bagindex/ServerTestSupportFixture.scala
@@ -40,5 +40,5 @@ trait ServerTestSupportFixture {
     }
   }
 
-  def successful: (Int, String) = (200, "EASY Bag Index running.")
+  def successful(version: String): (Int, String) = (200, s"EASY Bag Index running v$version\n.") //TODO how does this newline end up in the response?
 }

--- a/src/test/scala/nl/knaw/dans/easy/bagindex/server/BagIndexServletSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/bagindex/server/BagIndexServletSpec.scala
@@ -40,9 +40,13 @@ class BagIndexServletSpec extends TestSupportFixture
   with IndexBagComponent
   with DatabaseComponent {
 
+  private val testVersion: String = "1.0.0"
+
   override val database: Database = new Database {}
   override val index: IndexBag = new IndexBag {}
-  override val bagIndexServlet = new BagIndexServlet {}
+  override val bagIndexServlet = new BagIndexServlet {
+    override val version: String = testVersion
+  }
 
   override def beforeAll(): Unit = {
     super.beforeAll()
@@ -53,7 +57,7 @@ class BagIndexServletSpec extends TestSupportFixture
   "get" should "signal that the service is running" in {
     get("/") {
       status shouldBe 200
-      body shouldBe "EASY Bag Index running."
+      body shouldBe s"EASY Bag Index running v$testVersion."
     }
   }
 

--- a/src/test/scala/nl/knaw/dans/easy/bagindex/service/ServiceStarterSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/bagindex/service/ServiceStarterSpec.scala
@@ -79,6 +79,6 @@ class ServiceStarterSpec extends TestSupportFixture
   }
 
   "calling GET /" should "check that the service is up and running" in {
-    callService() shouldBe successful
+    callService() shouldBe successful(configuration.version)
   }
 }


### PR DESCRIPTION
Fixes EASY-2002

#### When applied it will...
* add version to the baseurl response 

- [x] somehow a \n ended up in a test response 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github

repo                       | PR
-------------------------- | -----------------
easy-                      | [PR#](PRlink) 
