### PR TITLE
NO-JIRA: add 'if not exists' expressions to 'create table' in db script

### DIFF
--- a/src/main/assembly/dist/install/db-tables.sql
+++ b/src/main/assembly/dist/install/db-tables.sql
@@ -1,4 +1,4 @@
-CREATE TABLE bag_info (
+CREATE TABLE IF NOT EXISTS bag_info (
     bagId CHAR(36) NOT NULL PRIMARY KEY,
     base CHAR(36) NOT NULL,
     created VARCHAR(29) NOT NULL,


### PR DESCRIPTION
~Fixes EASY-~

#### When applied it will
* add `if not exists` expressions to `create table` in db script

#### By submitting this pull request I confirm that
* [x] all files contain licenses (`mvn license:format`)
* [x] the project compiles (`mvn clean install`)
* [x] all unit tests pass (`mvn test`)
* [x] the changes have been tested on `deasy`

@DANS-KNAW/easy for review

#### Related pull request(s)
* [`easy-dtap`](https://github.com/DANS-KNAW/easy-dtap/pull/390)