### PR TITLE
EASY-2332: validation of UUIDs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ Index a bag store
 SYNOPSIS
 --------
 
-    easy-bag-index index [--force | -f] <item-id> # Retrieves the information from the cache or directly from the bag-store
+    easy-bag-index index [--force | -f]  [--bagId | -b <item-id>] # Retrieves the information from the cache or directly from the bag-store
     easy-bag-index run-service # Runs the program as a service
 
 DESCRIPTION
@@ -22,12 +22,10 @@ ARGUMENTS
     -h, --help      Show help message
     -v, --version   Show version of this program
 
-    Subcommand: index - Starts EASY bag index as a daemon that services HTTP requests
+    Subcommand: index - Adds one bag or the whole bag-store to the index
+        -b, --bagId  <arg>   the bag identifier to be added
         -f, --force  Force the indexing without asking for confirmation
         -h, --help   Show help message
-
-    trailing arguments:
-           item-id (required)
 
     ---
 

--- a/pom.xml
+++ b/pom.xml
@@ -78,13 +78,6 @@
         <dependency>
             <groupId>nl.knaw.dans.lib</groupId>
             <artifactId>dans-scala-lib_2.12</artifactId>
-            <version>1.6.0</version>
-        </dependency>
-
-        <!-- dans lib -->
-        <dependency>
-            <groupId>nl.knaw.dans.lib</groupId>
-            <artifactId>dans-scala-lib_2.12</artifactId>
             <version>1.6.1</version>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,13 @@
             <version>1.6.0</version>
         </dependency>
 
+        <!-- dans lib -->
+        <dependency>
+            <groupId>nl.knaw.dans.lib</groupId>
+            <artifactId>dans-scala-lib_2.12</artifactId>
+            <version>1.6.1</version>
+        </dependency>
+
         <!-- Apache Commons -->
         <dependency>
             <groupId>commons-io</groupId>

--- a/src/main/scala/nl.knaw.dans.easy.bagindex/access/BagFacadeComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagindex/access/BagFacadeComponent.scala
@@ -26,6 +26,7 @@ import gov.loc.repository.bagit.exceptions._
 import gov.loc.repository.bagit.reader.BagReader
 import nl.knaw.dans.easy.bagindex._
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
+import nl.knaw.dans.lib.string._
 import org.joda.time.DateTime
 
 import scala.collection.JavaConverters._
@@ -61,7 +62,7 @@ trait BagFacadeComponent extends DebugEnhancedLogging {
         val uuidPart = uri.getSchemeSpecificPart
         val parts = uuidPart.split(':')
         if (parts.length != 2) Failure(InvalidIsVersionOfException(bagDir, uri.toASCIIString))
-        else Try { UUID.fromString(parts(1)) }
+        else parts(1).toUUID.toTry
       }
       else Failure(InvalidIsVersionOfException(bagDir, uri.toASCIIString))
     }

--- a/src/main/scala/nl.knaw.dans.easy.bagindex/access/BagStoreAccessComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagindex/access/BagStoreAccessComponent.scala
@@ -21,6 +21,7 @@ import java.util.UUID
 import nl.knaw.dans.easy.bagindex.JavaOptionals._
 import nl.knaw.dans.easy.bagindex.{ BagId, BagNotFoundException, _ }
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
+import nl.knaw.dans.lib.string._
 import resource._
 
 import scala.annotation.tailrec
@@ -143,8 +144,11 @@ trait BagStoreAccessComponent extends DebugEnhancedLogging {
             .map(baseDir.relativize)
             .withFilter(_.getNameCount == depth)
             .map(path => {
-              val bagId = UUID.fromString(formatUuidStrCanonically(path.toString.filterNot(_ == '/')))
-              (bagId, findBag(baseDir.resolve(path)).get)
+              val bagId = formatUuidStrCanonically(path.toString.filterNot(_ == '/')).toUUID.toTry
+              bagId match {
+                case Success(uuid) => (bagId.get, findBag(baseDir.resolve(path)).get)
+                case Failure(error) => throw new Exception(error)
+              }
             })
         }
 

--- a/src/main/scala/nl.knaw.dans.easy.bagindex/access/BagStoreAccessComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagindex/access/BagStoreAccessComponent.scala
@@ -146,7 +146,7 @@ trait BagStoreAccessComponent extends DebugEnhancedLogging {
             .map(path => {
               val bagId = formatUuidStrCanonically(path.toString.filterNot(_ == '/')).toUUID.toTry
               bagId match {
-                case Success(uuid) => (bagId.get, findBag(baseDir.resolve(path)).get)
+                case Success(uuid) => (uuid, findBag(baseDir.resolve(path)).get)
                 case Failure(error) => throw new Exception(error)
               }
             })

--- a/src/main/scala/nl.knaw.dans.easy.bagindex/command/CommandLineOptionsComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagindex/command/CommandLineOptionsComponent.scala
@@ -18,8 +18,9 @@ package nl.knaw.dans.easy.bagindex.command
 import java.util.UUID
 
 import nl.knaw.dans.easy.bagindex.{ BagId, ConfigurationComponent }
+import nl.knaw.dans.lib.string._
 import org.joda.time.DateTime
-import org.rogach.scallop.{ ScallopConf, ScallopOption, Subcommand, singleArgConverter }
+import org.rogach.scallop.{ ScallopConf, ScallopOption, Subcommand, singleArgConverter, stringConverter }
 
 import scala.annotation.tailrec
 import scala.io.StdIn
@@ -44,13 +45,13 @@ trait CommandLineOptionsComponent {
          |Usage:
          |
          |$printedName \\
-         |${ _________ }| index [--force | -f] [bagId]
+         |${ _________ }| index [--force | -f] [-b bagId]
          |${ _________ }| run-service
          |
          |Options:
          |""".stripMargin)
 
-    private implicit val uuidConverter = singleArgConverter[UUID](UUID.fromString)
+    private implicit val uuidConverter = stringConverter.flatMap(_.toUUID.fold(e => Left(e.getMessage), uuid => Right(Option(uuid))))
     private implicit val dateTimeConverter = singleArgConverter[DateTime](DateTime.parse)
 
     val index = new Subcommand("index") {
@@ -59,7 +60,7 @@ trait CommandLineOptionsComponent {
       val force: ScallopOption[Boolean] = opt(name = "force", short = 'f', default = Some(false),
         descr = "force the indexing without asking for confirmation")
 
-      val bagId: ScallopOption[BagId] = trailArg[UUID](name = "bagId",
+      val bagId: ScallopOption[BagId] = opt(name = "bagId", short = 'b',
         descr = "the bag identifier to be added",
         required = false)
       footer(SUBCOMMAND_SEPARATOR)

--- a/src/main/scala/nl.knaw.dans.easy.bagindex/command/CommandLineOptionsComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagindex/command/CommandLineOptionsComponent.scala
@@ -45,7 +45,7 @@ trait CommandLineOptionsComponent {
          |Usage:
          |
          |$printedName \\
-         |${ _________ }| index [--force | -f] [-b bagId]
+         |${ _________ }| index [--force | -f] [--bagId | -b <bagId>]
          |${ _________ }| run-service
          |
          |Options:

--- a/src/main/scala/nl.knaw.dans.easy.bagindex/server/BagIndexServletComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagindex/server/BagIndexServletComponent.scala
@@ -15,14 +15,13 @@
  */
 package nl.knaw.dans.easy.bagindex.server
 
-import java.util.UUID
-
 import nl.knaw.dans.easy.bagindex._
 import nl.knaw.dans.easy.bagindex.access.DatabaseAccessComponent
 import nl.knaw.dans.easy.bagindex.components.{ DatabaseComponent, IndexBagComponent }
 import nl.knaw.dans.lib.error._
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import nl.knaw.dans.lib.logging.servlet._
+import nl.knaw.dans.lib.string._
 import org.joda.time.DateTime
 import org.json4s.JValue
 import org.json4s.JsonDSL._
@@ -107,7 +106,7 @@ trait BagIndexServletComponent {
       contentType = "text/plain"
       params.get("contains")
         .map(uuidStr => {
-          Try { UUID.fromString(uuidStr) }
+          uuidStr.toUUID.toTry
             .recoverWith {
               case _: IllegalArgumentException => Failure(new IllegalArgumentException(s"invalid UUID string: $uuidStr"))
             }
@@ -127,7 +126,7 @@ trait BagIndexServletComponent {
     // the data is returned as JSON by default or XML when specified (content-type application/xml or text/xml)
     get("/bags/:bagId") {
       val uuidStr = params("bagId")
-      Try { UUID.fromString(uuidStr) }
+      uuidStr.toUUID.toTry
         .recoverWith {
           case _: IllegalArgumentException => Failure(new IllegalArgumentException(s"invalid UUID string: $uuidStr"))
         }
@@ -147,7 +146,7 @@ trait BagIndexServletComponent {
     // based on this, add a record to the index/database
     put("/bags/:bagId") {
       val uuidStr = params("bagId")
-      Try { UUID.fromString(uuidStr) }
+      uuidStr.toUUID.toTry
         .recoverWith {
           case _: IllegalArgumentException => Failure(new IllegalArgumentException(s"invalid UUID string: $uuidStr"))
         }

--- a/src/test/scala/nl/knaw/dans/easy/bagindex/server/BagIndexServletSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/bagindex/server/BagIndexServletSpec.scala
@@ -168,14 +168,14 @@ class BagIndexServletSpec extends TestSupportFixture
   it should "fail when the parameter 'contains' is not a well-formatted UUID" in {
     get("/bag-sequence", "contains" -> "abc-def-ghi-jkl-mno") {
       status shouldBe 400
-      body shouldBe "invalid UUID string: abc-def-ghi-jkl-mno"
+      body shouldBe "String 'abc-def-ghi-jkl-mno' is not a UUID"
     }
   }
 
   it should "fail when the parameter 'contains' is not a UUID" in {
     get("/bag-sequence", "contains" -> "foobar") {
       status shouldBe 400
-      body shouldBe "invalid UUID string: foobar"
+      body shouldBe "String 'foobar' is not a UUID"
     }
   }
 
@@ -248,14 +248,14 @@ class BagIndexServletSpec extends TestSupportFixture
   it should "fail when the parameter 'bagId' is not a well-formatted UUID" in {
     get("/bags/abc-def-ghi-jkl-mno") {
       status shouldBe 400
-      body shouldBe "invalid UUID string: abc-def-ghi-jkl-mno"
+      body shouldBe "String 'abc-def-ghi-jkl-mno' is not a UUID"
     }
   }
 
   it should "fail when the parameter 'bagId' is not a UUID" in {
     get("/bags/foobar") {
       status shouldBe 400
-      body shouldBe "invalid UUID string: foobar"
+      body shouldBe "String 'foobar' is not a UUID"
     }
   }
 
@@ -300,14 +300,14 @@ class BagIndexServletSpec extends TestSupportFixture
   it should "fail when the parameter 'bagId' is not a well-formatted UUID" in {
     put("/bags/abc-def-ghi-jkl-mno") {
       status shouldBe 400
-      body shouldBe "invalid UUID string: abc-def-ghi-jkl-mno"
+      body shouldBe "String 'abc-def-ghi-jkl-mno' is not a UUID"
     }
   }
 
   it should "fail when the parameter 'bagId' is not a UUID" in {
     put("/bags/foobar") {
       status shouldBe 400
-      body shouldBe "invalid UUID string: foobar"
+      body shouldBe "String 'foobar' is not a UUID"
     }
   }
 }


### PR DESCRIPTION
Fixes EASY-2332

#### When applied it will
* validate `UUIDs` using `dans.lib.string.toUUID` method

**Note**: In the following classes `UUID` is created directly by calling `UUID.fromString` method because these bagId-strings come from already existing bags:
* IndexBagStoreDatabaseComponent, DatabaseComponent
#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github

repo                       | PR
-------------------------- | -----------------
easy-archive-bag   | [PR#66](https://github.com/DANS-KNAW/easy-archive-bag/pull/66)     | ..
easy-auth-info   | [PR#36](https://github.com/DANS-KNAW/easy-auth-info/pull/36)     | ..
easy-bag-store  | [PR#100](https://github.com/DANS-KNAW/easy-bag-store/pull/100)     | ..
easy-delete-dataset  | [PR#19](https://github.com/DANS-KNAW/easy-delete-dataset/pull/19)     | ..
easy-deposit-api  | [PR#204](https://github.com/DANS-KNAW/easy-deposit-api/pull/204)     | ..
easy-deposit-properties  | [PR#23](https://github.com/DANS-KNAW/easy-deposit-properties/pull/23)     | ..
easy-ingest-flow  | [PR#137](https://github.com/DANS-KNAW/easy-ingest-flow/pull/137)     | ..
easy-solr4files-index  | [PR#54](https://github.com/DANS-KNAW/easy-solr4files-index/pull/54)     | ..
easy-split-multi-deposit  | [PR#146](https://github.com/DANS-KNAW/easy-split-multi-deposit/pull/146)     | ..
easy-transform-metadata  | [PR#11](https://github.com/DANS-KNAW/easy-transform-metadata/pull/11)     | ..
easy-validate-dans-bag  | [PR#73](https://github.com/DANS-KNAW/easy-validate-dans-bag/pull/73)     | ..

