### PR TITLE
EASY-2179: update scalatra

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-scala-app-project</artifactId>
-        <version>6.0.2-SNAPSHOT</version>
+        <version>6.0.2</version>
     </parent>
 
     <groupId>nl.knaw.dans.easy</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-scala-app-project</artifactId>
-        <version>6.0.1</version>
+        <version>6.0.2-SNAPSHOT</version>
     </parent>
 
     <groupId>nl.knaw.dans.easy</groupId>

--- a/src/main/scala/nl.knaw.dans.easy.bagindex/server/BagIndexServletComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagindex/server/BagIndexServletComponent.scala
@@ -86,7 +86,7 @@ trait BagIndexServletComponent {
       }
 
       Option(params)
-        .filter(_.nonEmpty)
+        .filter(_.size > 0)
         .map(params => {
           lazy val doi = params.get("doi").map(searchWithDoi)
           doi

--- a/src/test/scala/nl/knaw/dans/easy/bagindex/ServerTestSupportFixture.scala
+++ b/src/test/scala/nl/knaw/dans/easy/bagindex/ServerTestSupportFixture.scala
@@ -16,6 +16,7 @@
 package nl.knaw.dans.easy.bagindex
 
 import java.net.{ HttpURLConnection, URL }
+import java.nio.charset.StandardCharsets
 
 import org.apache.commons.io.IOUtils
 import resource.managed
@@ -33,8 +34,8 @@ trait ServerTestSupportFixture {
         }
           .map(_.getResponseCode)
           .acquireAndGet {
-            case code if code >= 200 && code < 300 => (code, IOUtils.toString(conn.getInputStream))
-            case code => (code, IOUtils.toString(conn.getErrorStream))
+            case code if code >= 200 && code < 300 => (code, IOUtils.toString(conn.getInputStream, StandardCharsets.UTF_8))
+            case code => (code, IOUtils.toString(conn.getErrorStream, StandardCharsets.UTF_8))
           }
       case _ => throw new Exception
     }

--- a/src/test/scala/nl/knaw/dans/easy/bagindex/TestSupportFixture.scala
+++ b/src/test/scala/nl/knaw/dans/easy/bagindex/TestSupportFixture.scala
@@ -18,9 +18,11 @@ package nl.knaw.dans.easy.bagindex
 import java.nio.file.{ Files, Path, Paths }
 
 import org.apache.commons.io.FileUtils
-import org.scalatest._
+import org.scalatest.Inside
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-trait TestSupportFixture extends FlatSpec with Matchers with Inside {
+trait TestSupportFixture extends AnyFlatSpec with Matchers with Inside {
 
   lazy val testDir: Path = {
     val path = Paths.get(s"target/test/${ getClass.getSimpleName }").toAbsolutePath


### PR DESCRIPTION
fixes EASY-2179

#### When applied it will
* update parent POM version
* fix deprecation warnings
* fix scalatra's breaking changes

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### related pull requests on github
repo                       | PR                | Note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     |
