### PR TITLE
EASY-2856: easy-bag-index add name of server in attachment name

### DIFF
--- a/src/main/assembly/dist/bin/create-and-send-doi-report.sh
+++ b/src/main/assembly/dist/bin/create-and-send-doi-report.sh
@@ -12,7 +12,7 @@ TO=$4
 BCC=$5
 TMPDIR=/tmp
 DATE=$(date +%Y-%m-%d)
-REPORT=$TMPDIR/$DOI_PREFIX-doi-report-$DATE.csv
+REPORT=$TMPDIR/$DARK_HOST-$DOI_PREFIX-doi-report-$DATE.csv
 MINDEPTH=3
 MAXDEPTH=5
 


### PR DESCRIPTION
Fixes EASY-2856

#### When applied it will...
* add `server name` to the `doi-report name`

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github

repo                       | PR
-------------------------- | -----------------
easy-dtap                      | [PR#516](https://github.com/DANS-KNAW/easy-dtap/pull/516) 
